### PR TITLE
Add #ajax to dropdown select, hide button

### DIFF
--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -18,12 +18,8 @@ use Drupal\entity_browser\Events\RegisterJSCallbacks;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\KernelEvents;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\CloseDialogCommand;
-use Drupal\Core\Ajax\SettingsCommand;
 use Drupal\entity_browser\Ajax\SelectEntitiesCommand;
 use Drupal\Core\Form\FormStateInterface;
 
@@ -177,7 +173,7 @@ class Modal extends DisplayBase implements DisplayRouterInterface, DisplayAjaxIn
     );
 
     $form['actions']['submit']['#ajax'] = array(
-      'callback' => array(get_class($this), 'widgetAjaxCallback'),
+      'callback' => array($this, 'widgetAjaxCallback'),
       'wrapper' =>  $this->configuration['entity_browser_id'],
     );
   }

--- a/src/Plugin/EntityBrowser/WidgetSelector/DropDown.php
+++ b/src/Plugin/EntityBrowser/WidgetSelector/DropDown.php
@@ -33,17 +33,19 @@ class DropDown extends WidgetSelectorBase {
       '#type' => 'select',
       '#options' => $this->widget_ids,
       '#default_value' => $this->getCurrentWidget(),
+      '#executes_submit_callback' => TRUE,
+      '#limit_validation_errors' => array(array('widget')),
+      '#ajax' => array(
+        'callback' => array($this, 'changeWidgetCallback'),
+        'wrapper' => 'entity-browser-form',
+      ),
     );
 
     $element['change'] = array(
       '#type' => 'submit',
       '#name' => 'change',
       '#value' => t('Change'),
-      '#limit_validation_errors' => array(array('widget')),
-      '#ajax' => array(
-        'callback' => array($this, 'changeWidgetCallback'),
-        'wrapper' => 'entity-browser-form',
-      ),
+      '#attributes' => array('class' => array('js-hide')),
     );
 
     return $element;


### PR DESCRIPTION
The modal changes are not really related, but the Modal was completely broken for me, a recent commit added the get_class() thing, but that makes no sense, widgetAjaxCallback needs to access $this->selectedEntities at the moment.
