### PR TITLE
2397853 Make EntityBrowser responsible for remembering the current widget

### DIFF
--- a/src/EntityBrowserInterface.php
+++ b/src/EntityBrowserInterface.php
@@ -9,6 +9,7 @@ namespace Drupal\entity_browser;
 
 use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Form\FormInterface;
+use Drupal\Core\Form\FormStateInterface;
 
 /**
  * Provides an interface defining an entity browser entity.
@@ -146,6 +147,17 @@ interface EntityBrowserInterface extends ConfigEntityInterface, FormInterface {
    *   Entities to be added to the list of currently selected entities.
    */
   public function addSelectedEntities(array $entities);
+
+  /**
+   * Returns the widget that is currently selected.
+   *
+   *  @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return string
+   *   ID of currently selected widget.
+   */
+  public function getCurrentWidget(FormStateInterface $form_state);
 
   /**
    * Gets route that matches this display.

--- a/src/EntityBrowserInterface.php
+++ b/src/EntityBrowserInterface.php
@@ -87,8 +87,11 @@ interface EntityBrowserInterface extends ConfigEntityInterface, FormInterface {
    * Resets widgets on the entity browser.
    *
    * Used when widgets configurations change, such as changing weights.
+   *
+   *  @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
    */
-  public function resetWidgets();
+  public function resetWidgets(FormStateInterface $form_state);
 
   /**
    * Adds paramterers that will be passed to the widget.

--- a/src/Plugin/EntityBrowser/WidgetSelector/DropDown.php
+++ b/src/Plugin/EntityBrowser/WidgetSelector/DropDown.php
@@ -32,7 +32,7 @@ class DropDown extends WidgetSelectorBase {
     $element['widget'] = array(
       '#type' => 'select',
       '#options' => $this->widget_ids,
-      '#default_value' => $this->getCurrentWidget(),
+      '#default_value' => $this->getDefaultWidget(),
     );
 
     $element['change'] = array(
@@ -53,12 +53,7 @@ class DropDown extends WidgetSelectorBase {
    * {@inheritdoc}
    */
   public function submit(array &$form, FormStateInterface $form_state) {
-    // If we've submitted the form, update the current widget.
-    if ($form_state->getValue('widget')) {
-      $this->setCurrentWidget($form_state->getValue('widget'));
-    }
-
-    $form_state->setRebuild();
+    return $form_state->getValue('widget');
   }
 
   /**

--- a/src/Tests/EntityBrowserTest.php
+++ b/src/Tests/EntityBrowserTest.php
@@ -284,7 +284,7 @@ class EntityBrowserTest extends KernelTestBase {
 
     // Change weight and expect second widget to become first.
     $widget->setWeight(3);
-    $entity->resetWidgets();
+    $entity->resetWidgets($form_state);
     $new_widget = $entity->getWidgets()->get($entity->getCurrentWidget($form_state));
     $this->assertEqual($new_widget->label(), 'View widget nr. 2', 'Second widget is active after changing widgets');
   }
@@ -295,12 +295,13 @@ class EntityBrowserTest extends KernelTestBase {
   protected function testSelectedEvent() {
     $this->installConfig(array('entity_browser_test'));
 
-    /** @var $entity \Drupal\entity_browser\EntityBrowserInterface */
-    $entity = $this->controller->load('dummy_widget');
-    $entity->getWidgets()->get($entity->getWidgetSelector()->getCurrentWidget())->entity = $entity;
-
     $form_state = new FormState();
     $form = [];
+
+    /** @var $entity \Drupal\entity_browser\EntityBrowserInterface */
+    $entity = $this->controller->load('dummy_widget');
+    $entity->getWidgets()->get($entity->getCurrentWidget($form_state))->entity = $entity;
+
     $form = $entity->buildForm($form, new $form_state);
     $entity->submitForm($form, $form_state);
 

--- a/src/Tests/EntityBrowserTest.php
+++ b/src/Tests/EntityBrowserTest.php
@@ -269,40 +269,23 @@ class EntityBrowserTest extends KernelTestBase {
   }
 
   /**
-   * Test single widget selector.
+   * Tests default widget selector.
    */
-  protected function testSingleWidgetSelector() {
+  protected function testDefaultWidget() {
     $this->installConfig(array('entity_browser_test'));
 
     /** @var $entity \Drupal\entity_browser\EntityBrowserInterface */
     $entity = $this->controller->load('test');
 
-    $widget = $entity->getWidgets()->get($entity->getWidgetSelector()->getCurrentWidget());
+    $form_state = new FormState();
+
+    $widget = $entity->getWidgets()->get($entity->getCurrentWidget($form_state));
     $this->assertEqual($widget->label(), 'View widget nr. 1', 'First widget is active.');
 
     // Change weight and expect second widget to become first.
     $widget->setWeight(3);
     $entity->resetWidgets();
-    $new_widget = $entity->getWidgets()->get($entity->getWidgetSelector()->getCurrentWidget());
-    $this->assertEqual($new_widget->label(), 'View widget nr. 2', 'Second widget is active after changing widgets');
-  }
-
-  /**
-   * Test drop_down widget selector.
-   */
-  protected function testDropDownWidgetSelector() {
-    $this->installConfig(array('entity_browser_test'));
-
-    /** @var $entity \Drupal\entity_browser\EntityBrowserInterface */
-    $entity = $this->controller->load('test_dropdown');
-
-    $widget = $widget = $entity->getWidgets()->get($entity->getWidgetSelector()->getCurrentWidget());
-    $this->assertEqual($widget->label(), 'Upload', 'First widget is active.');
-
-    // Change weight and expect second widget to become first.
-    $widget->setWeight(3);
-    $entity->resetWidgets();
-    $new_widget = $entity->getWidgets()->get($entity->getWidgetSelector()->getCurrentWidget());
+    $new_widget = $entity->getWidgets()->get($entity->getCurrentWidget($form_state));
     $this->assertEqual($new_widget->label(), 'View widget nr. 2', 'Second widget is active after changing widgets');
   }
 

--- a/src/WidgetSelectorBase.php
+++ b/src/WidgetSelectorBase.php
@@ -31,11 +31,11 @@ abstract class WidgetSelectorBase extends PluginBase implements WidgetSelectorIn
   protected $widgets_options;
 
   /**
-   * Id of Current Widget.
+   * ID of the default widget.
    *
    * @var string
    */
-  protected $currentWidget;
+  protected $defaultWidget;
 
   /**
    * {@inheritdoc}
@@ -55,34 +55,15 @@ abstract class WidgetSelectorBase extends PluginBase implements WidgetSelectorIn
   /**
    * {@inheritdoc}
    */
-  public function getCurrentWidget() {
-    if (!$this->currentWidget) {
-      $this->currentWidget = $this->getFirstWidget($this->widget_ids);
-    }
-
-    return $this->currentWidget;
+  protected function getDefaultWidget() {
+    return $this->defaultWidget;
   }
 
   /**
    * {@inheritdoc}
    */
-  public function setCurrentWidget($widget) {
-    $this->currentWidget = $widget;
-  }
-
-  /**
-   * Gets first widget based on weights.
-   *
-   * @param array $widget_ids
-   *   Array of all the widgets.
-   *
-   * @return array
-   *   First element of the array.
-   */
-  protected function getFirstWidget(array $widget_ids) {
-    reset($widget_ids);
-    
-    return key($widget_ids);
+  public function setDefaultWidget($widget) {
+    $this->defaultWidget = $widget;
   }
 
   /**

--- a/src/WidgetSelectorInterface.php
+++ b/src/WidgetSelectorInterface.php
@@ -33,20 +33,12 @@ interface WidgetSelectorInterface extends PluginInspectionInterface {
   public function getForm(array &$form, FormStateInterface &$form_state);
 
   /**
-   * Returns the widget that is currently selected.
-   *
-   * @return string
-   *   ID of currently selected widget.
-   */
-  public function getCurrentWidget();
-
-  /**
-   * Sets the current widget.
+   * Sets the default widget.
    *
    * @param string $widget
    *   Id of widget to set as the current widget.
    */
-  public function setCurrentWidget($widget);
+  public function setDefaultWidget($widget);
 
   /**
    * Validates form.
@@ -65,6 +57,9 @@ interface WidgetSelectorInterface extends PluginInspectionInterface {
    *   Form.
    * @param \Drupal\Core\Form\FormStateInterface $form_state
    *   Form state object.
+   *
+   * @return string
+   *   The selected widget ID.
    */
   public function submit(array &$form, FormStateInterface $form_state);
 


### PR DESCRIPTION
Alternative solution for https://github.com/drupal-media/entity_browser/pull/42

Make the entity browser responsible for remembering the current widget, then we don't lose it and the logic works as intended. What I'm not sure is if it should be kept in $form_state or not. It seems to be the safest place with all that serializing and _sleep() stuff going on, but it makes the interfaces and methods more complex as they have to pass $form_state around. I think we keep the selectedEntities on the object as well, so that would probably be just as safe. Thoughts?

That said, I do think that it would be good to make two submit callbacks of submitForm(), as it is doing two completely different things right now.  But that's a separate issue.
