### PR TITLE
Issue #2400441: Added modal display in entity_browser_example.

### DIFF
--- a/modules/example/config/install/core.entity_form_display.node.entity_browser_test.default.yml
+++ b/modules/example/config/install/core.entity_form_display.node.entity_browser_test.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.entity_browser_test.body
     - field.field.node.entity_browser_test.field_files
+    - field.field.node.entity_browser_test.field_files1
     - field.field.node.entity_browser_test.field_nodes
     - node.type.entity_browser_test
   module:
@@ -70,9 +71,17 @@ content:
       field_widget_display: label
       field_widget_display_settings: []
     third_party_settings: {  }
-  field_nodes:
+  field_files1:
     type: entity_browser_entity_reference
     weight: 33
+    settings:
+      entity_browser: test_files1
+      field_widget_display: label
+      field_widget_display_settings: []
+    third_party_settings: {  }
+  field_nodes:
+    type: entity_browser_entity_reference
+    weight: 34
     settings:
       entity_browser: test_nodes
       field_widget_display: label

--- a/modules/example/config/install/core.entity_view_display.node.entity_browser_test.default.yml
+++ b/modules/example/config/install/core.entity_view_display.node.entity_browser_test.default.yml
@@ -4,6 +4,7 @@ dependencies:
   config:
     - field.field.node.entity_browser_test.body
     - field.field.node.entity_browser_test.field_files
+    - field.field.node.entity_browser_test.field_files1
     - field.field.node.entity_browser_test.field_nodes
     - node.type.entity_browser_test
   module:
@@ -31,8 +32,15 @@ content:
       link: true
     third_party_settings: {  }
     type: entity_reference_label
-  field_nodes:
+  field_files1:
     weight: 103
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_nodes:
+    weight: 104
     label: above
     settings:
       link: true

--- a/modules/example/config/install/entity_browser.browser.test_files1.yml
+++ b/modules/example/config/install/entity_browser.browser.test_files1.yml
@@ -1,0 +1,22 @@
+langcode: und
+status: true
+dependencies: {  }
+name: test_files1
+label: 'Test entity browser for files'
+display: modal
+display_configuration:
+  width: 650
+  height: 500
+  link_text: 'Select entities'
+selection_display: no_display
+selection_display_configuration: {  }
+widget_selector: single
+widget_selector_configuration: {  }
+widgets:
+  735d146c-a4b2-4327-a057-d109e0905e05:
+    settings:
+      upload_location: 'public://'
+    uuid: 735d146c-a4b2-4327-a057-d109e0905e05
+    weight: 0
+    label: 'Upload files'
+    id: upload

--- a/modules/example/config/install/field.field.node.entity_browser_test.field_files1.yml
+++ b/modules/example/config/install/field.field.node.entity_browser_test.field_files1.yml
@@ -1,0 +1,26 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_files1
+    - node.type.entity_browser_test
+  module:
+    - entity_reference
+id: node.entity_browser_test.field_files1
+field_name: field_files1
+entity_type: node
+bundle: entity_browser_test
+label: Files
+description: 'Attach files. Click on the link below and upload them.'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: default
+  handler_settings:
+    target_bundles: {  }
+    sort:
+      field: _none
+third_party_settings: {  }
+field_type: entity_reference

--- a/modules/example/config/install/field.storage.node.field_files1.yml
+++ b/modules/example/config/install/field.storage.node.field_files1.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference
+    - node
+id: node.field_files1
+field_name: field_files1
+entity_type: node
+type: entity_reference
+settings:
+  target_type: file
+module: entity_reference
+locked: false
+cardinality: -1
+translatable: false
+indexes: {  }
+persist_with_no_fields: false


### PR DESCRIPTION
Issue on d.o: https://www.drupal.org/node/2400441
Replicated the field_files entity_reference field from another example. The entity browser has only one widget (files upload).
