### PR TITLE
Fix regression where EntityBrowser form was not cached.

### DIFF
--- a/src/EntityBrowserForm.php
+++ b/src/EntityBrowserForm.php
@@ -28,6 +28,8 @@ class EntityBrowserForm extends EntityForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
+    $form_state->disableCache();
+
     $entity_browser = $this->entity;
     $form['selected_entities'] = array(
       '#type' => 'value',


### PR DESCRIPTION
This PR copies the code from #35, which disables form caching for the EntityBrowser entity.
