### PR TITLE
Added sanity check in IFrame::propagateSelection to fix multi-widget bug

### DIFF
--- a/src/Plugin/EntityBrowser/Display/IFrame.php
+++ b/src/Plugin/EntityBrowser/Display/IFrame.php
@@ -165,6 +165,10 @@ class IFrame extends DisplayBase implements DisplayRouterInterface {
    *   Response event.
    */
   public function propagateSelection(FilterResponseEvent $event) {
+    if (empty($this->entities)) {
+      return;
+    }
+
     $render = [
       'labels' => [
         '#markup' => 'Labels: ' . implode(', ', array_map(function (EntityInterface $item) {return $item->label();}, $this->entities)),


### PR DESCRIPTION
This fixes a bug that can be seen when using the dropdown and selecting back and forth between different widgets. Eventually, this method will be called and override the widget's JSON response.
