### PR TITLE
Added theme override for the iframe entity browser.

### DIFF
--- a/entity_browser.module
+++ b/entity_browser.module
@@ -2,5 +2,20 @@
 
 /**
  * @file
- * Allows to flexibly create, browse and select entites.
+ * Allows to flexibly create, browse and select entities.
  */
+
+/**
+ * Implements hook_theme().
+ *
+ * Overrides the core html theme to use a custom template for iframes.
+ */
+function entity_browser_theme() {
+  return [
+    'html__entity_browser__iframe' => array(
+      'template' => 'html--entity-browser--iframe',
+      'render element' => 'html',
+      'preprocess functions' => ['template_preprocess_html']
+    ),
+  ];
+}

--- a/templates/html--entity-browser--iframe.html.twig
+++ b/templates/html--entity-browser--iframe.html.twig
@@ -1,0 +1,47 @@
+{#
+/**
+ * @file
+ * Theme override for the IFrame entity browser. Template copied from core/modules/system/templates/html.html.twig
+ *
+ * Variables:
+ * - logged_in: A flag indicating if user is logged in.
+ * - root_path: The root path of the current page (e.g., node, admin, user).
+ * - node_type: The content type for the current node, if the page is a node.
+ * - css: A list of CSS files for the current page.
+ * - head: Markup for the HEAD element (including meta tags, keyword tags, and
+ *   so on).
+ * - head_title: List of text elements that make up the head_title variable.
+ *   May contain or more of the following:
+ *   - title: The title of the page.
+ *   - name: The name of the site.
+ *   - slogan: The slogan of the site.
+ * - page_top: Initial rendered markup. This should be printed before 'page'.
+ * - page: The rendered page markup.
+ * - page_bottom: Closing rendered markup. This variable should be printed after
+ *   'page'.
+ * - styles: Style tags necessary to import all necessary CSS files in the head.
+ * - scripts: Script tags necessary to load the JavaScript files and settings
+ *   in the head.
+ * - db_offline: A flag indicating if the database is offline.
+ *
+ * @see template_preprocess_html()
+ *
+ * @ingroup themeable
+ */
+#}
+<!DOCTYPE html>
+<html{{ html_attributes }}>
+<head>
+    {{ head }}
+    <title>{{ head_title|safe_join(' | ') }}</title>
+    {{ styles }}
+    {{ scripts }}
+</head>
+<body{{ attributes }}>
+<a href="#main-content" class="visually-hidden focusable">
+    {{ 'Skip to main content'|t }}
+</a>
+{{ page }}
+{{ scripts_bottom }}
+</body>
+</html>


### PR DESCRIPTION
This addresses an issue filed on drupal.org, https://www.drupal.org/node/2512714

Basically, this overrides the current theme's html template to only show the page, hiding page_top and page_bottom (header and footer).

An alternative to this is using hook_preprocess_html to unset arbitrary variables, but my main issue with that is that we lose control over the html output, in case we ever want to modify it further.
