### PR TITLE
First attempt at displayed exposed filters in a block.

### DIFF
--- a/src/Plugin/EntityBrowser/Widget/View.php
+++ b/src/Plugin/EntityBrowser/Widget/View.php
@@ -85,6 +85,37 @@ class View extends WidgetBase {
       }
     }
 
+    // Get the exposed filter as a block, if present
+    if ($view->display_handler->getOption('exposed_block')) {
+      $plugin_id = 'views_exposed_filter_block:' . $view->id() . '-' . $view->current_display;
+      $block_id = 'exposedform' . $view->id() . $view->current_display;
+
+      // Attempt to load block
+      if (!$block = \Drupal\block\Entity\Block::load($block_id)) {
+        // Create block if it doesn't exist
+        $settings = [
+          'plugin' => $plugin_id,
+          'id' => $block_id,
+          'settings' => [
+            'id' => $plugin_id,
+            'provider' => 'views',
+          ]
+        ];
+        $block = \Drupal\block\Entity\Block::create($settings);
+        $block->save();
+
+        // Load the new block
+        $block = \Drupal\block\Entity\Block::load($block_id);
+      }
+
+      // Build the render array
+      $exposed_form = \Drupal::entityManager()
+        ->getViewBuilder('block')
+        ->view($block);
+
+      $form['view']['exposed_form'] = $exposed_form;
+    }
+
     $form['view']['view'] = [
       '#markup' => \Drupal::service('renderer')->render($form['view']['view']),
     ];

--- a/src/Plugin/views/display/EntityBrowser.php
+++ b/src/Plugin/views/display/EntityBrowser.php
@@ -30,9 +30,28 @@ class EntityBrowser extends DisplayPluginBase {
    */
   public function execute() {
     parent::execute();
+    $this->has_exposed = FALSE;
     $render = ['view' => $this->view->render()];
+
     $this->handleForm($render);
     return $render;
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  public function usesExposedFormInBlock() {
+    return TRUE;
+  }
+
+  /**
+   * {@inheritdoc}.
+   */
+  protected function defineOptions() {
+    // Push users towards exposing filters as a block
+    $options = parent::defineOptions();
+    $options['exposed_block']['default'] = TRUE;
+    return $options;
   }
 
   /**


### PR DESCRIPTION
This is a first attempt at displaying exposed filters in blocks instead of inline with the view. The hope with this work is that by rendering filters in a block we can circumvent the AJAX weirdness we've been seeing across the board. I'm currently testing with the dropdown widget selector, as I think AJAX support is vital to having modals work.

Currently this breaks views with exposed filters in blocks, but that may be due to how I'm rendering/loading the block. This PR is to track progress and review, not to actually merge into 8.x-1.x.
