### PR TITLE
Remove duplicates while selecting from entity_browser

### DIFF
--- a/js/entity_browser.common.js
+++ b/js/entity_browser.common.js
@@ -21,13 +21,10 @@
    */
   Drupal.entityBrowser.selectionCompleted = function(event, uuid, entities) {
     // Update value form element with new entity IDs.
-    var entity_ids = $(this).parent().parent().find('input[type*=hidden]').val();
-    if (entity_ids.length != 0) {
-      entity_ids = entity_ids + ' ';
-    }
-
-    entity_ids = entity_ids + $.map(entities, function(item) {return item[0]}).join(' ');
-    $(this).parent().parent().find('input[type*=hidden]').val(entity_ids);
+    var entity_ids = $(this).parent().parent().find('input[type*=hidden]').val().split(" ");
+    var selected_entity_ids = $.map(entities, function(item) {return item[0]});
+    var entity_ids = _.union(entity_ids, selected_entity_ids);
+    $(this).parent().parent().find('input[type*=hidden]').val(entity_ids.join(" "));
     $(this).parent().parent().find('input[type*=hidden]').trigger('entity_browser_value_updated');
   };
 


### PR DESCRIPTION
Currently when entities are selected from the entity browser there is no way to avoid the duplicates. This patch tries to fix that by removing the duplicates before updating the input field.
