### PR TITLE
$instance_uuid not passed to RegisterJSCallbacks::__construct() in built in Displays.

### DIFF
--- a/src/Entity/EntityBrowser.php
+++ b/src/Entity/EntityBrowser.php
@@ -188,6 +188,7 @@ class EntityBrowser extends ConfigEntityBase implements EntityBrowserInterface, 
    */
   protected function displayPluginCollection() {
     if (!$this->displayCollection) {
+      $this->display_configuration['instance_uuid'] = $this->uuid();
       $this->display_configuration['entity_browser_id'] = $this->id();
       $this->displayCollection = new DefaultSingleLazyPluginCollection(\Drupal::service('plugin.manager.entity_browser.display'), $this->display, $this->display_configuration);
     }

--- a/src/Plugin/EntityBrowser/Display/IFrame.php
+++ b/src/Plugin/EntityBrowser/Display/IFrame.php
@@ -128,7 +128,8 @@ class IFrame extends DisplayBase implements DisplayRouterInterface {
    */
   public function displayEntityBrowser() {
     /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
-    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id']));
+    $callback_event = new RegisterJSCallbacks($this->configuration['entity_browser_id'], $this->configuration['instance_uuid']);
+    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, $callback_event);
     $uuid = $this->getUuid();
     $original_path = $this->currentPath->getPath();
     return [

--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -117,7 +117,8 @@ class Modal extends DisplayBase implements DisplayRouterInterface, DisplayAjaxIn
    */
   public function displayEntityBrowser() {
     /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
-    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id']));
+    $callback_event = new RegisterJSCallbacks($this->configuration['entity_browser_id'], $this->configuration['instance_uuid']);
+    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, $callback_event);
     $uuid = $this->getUuid();
     $original_path = $this->currentPath->getPath();
     return [


### PR DESCRIPTION
Copied from https://www.drupal.org/node/2600706:

> In both the Modal and IFrame Display plugins, the REGISTER_JS_CALLBACKS event is dispatched and RegisterJSCallbacks objects are created without passing the required $instance_uuid argument. I would submit a patch but I'm not sure where we can get an instance UUID for the Entity Browser (I believe it's abstracted from the Display Plugin). The relevant calls are in Modal::displayEntityBrowser() and IFrame::displayEntityBrowser().
