### PR TITLE
Ensured that using an Entity Browser does not actually save the Entity Browser entity.

### DIFF
--- a/src/Form/EntityBrowserForm.php
+++ b/src/Form/EntityBrowserForm.php
@@ -92,6 +92,14 @@ class EntityBrowserForm extends EntityForm {
   /**
    * {@inheritdoc}
    */
+  public function save(array $form, FormStateInterface $form_state) {
+    // Override our parent save method and do not touch the Entity Browser entity.
+    return;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     /** @var \Drupal\entity_browser\EntityBrowserInterface $entity_browser */
     $entity_browser = $this->entity;


### PR DESCRIPTION
Copied from https://www.drupal.org/node/2600708:

> My custom Entity Browser's display configuration seems to be lost after I use it once. Meaning - the width, height, and link_text are reset after I select files once.
> How to replicate:
> 1. Install https://www.drupal.org/project/file_browser
> 2. Use the provided Entity Browser (there's a pre-built example block, if you add a custom "File Browser" block you should see it.
> 3. Select a file or upload a file, then go back and re-open the browser (or refresh the page).
> 4. Notice that the area is smaller and the selection button says "Select entities" instead of the expected "Select files", and the width/height are now default.
> 
> It appears that this is happening because we added the "entity_browser" form as the Form handler for Entity Browser entities, which is causing the Entity Browser entity to be saved every time you use it. This normally would not be a problem but our form is unique in that it doesn't actually configure Entity Browser entities.

This PR overrides the normal ::save method in Drupal\entity_browser\Form\EntityBrowserForm and makes it so that when the form is used, the entity is never saved. If we ever add a UI for Entity Browsers, we'll need to create two forms: One for the current functionality and one that actually interacts with Entity Browser entities. For now, this fix seems acceptable to prevent unwanted saves (imagine how many times Entity Browser entities would be saved on a Prod site otherwise, :open_mouth:)
