### PR TITLE
Fix bug in IFrame.php.

### DIFF
--- a/src/Plugin/EntityBrowser/Display/IFrame.php
+++ b/src/Plugin/EntityBrowser/Display/IFrame.php
@@ -127,9 +127,9 @@ class IFrame extends DisplayBase implements DisplayRouterInterface {
    * {@inheritdoc}
    */
   public function displayEntityBrowser() {
-    /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
-    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id']));
     $uuid = $this->getUuid();
+    /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
+    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id'], $uuid));
     $original_path = $this->currentPath->getPath();
     return [
       '#theme_wrappers' => ['container'],

--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -116,9 +116,9 @@ class Modal extends DisplayBase implements DisplayRouterInterface, DisplayAjaxIn
    * {@inheritdoc}
    */
   public function displayEntityBrowser() {
-    /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
-    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id']));
     $uuid = $this->getUuid();
+    /** @var \Drupal\entity_browser\Events\RegisterJSCallbacks $event */
+    $event = $this->eventDispatcher->dispatch(Events::REGISTER_JS_CALLBACKS, new RegisterJSCallbacks($this->configuration['entity_browser_id'], $uuid));
     $original_path = $this->currentPath->getPath();
     return [
       '#theme_wrappers' => ['container'],


### PR DESCRIPTION
This bug fix prevents drupal from throwing an exception while trying to create a new instance of an EventBase object.

The issue I found was that the 2nd parameter (for the uuid) of EventBase::__construct() was missing.
