### PR TITLE
2616782 Only load the entities once in the field widget

### DIFF
--- a/src/Plugin/Field/FieldWidget/EntityReference.php
+++ b/src/Plugin/Field/FieldWidget/EntityReference.php
@@ -233,9 +233,10 @@ class EntityReference extends WidgetBase implements ContainerFactoryPluginInterf
       foreach ($items as $item) {
         $entity = $entity_storage->load($item->target_id);
         if (!empty($entity)) {
-          $ids[] = $item->target_id;
+          $entities[$item->target_id] = $entity;
         }
       }
+      $ids = array_keys($entities);
     }
     $ids = array_filter($ids);
 
@@ -283,8 +284,8 @@ class EntityReference extends WidgetBase implements ContainerFactoryPluginInterf
       '#theme_wrappers' => ['container'],
       '#attributes' => ['class' => ['entities-list']],
       'items' => array_map(
-        function($id) use ($entity_storage, $field_widget_display, $details_id, $field_parents) {
-          $entity = $entity_storage->load($id);
+        function($id) use ($entity_storage, $field_widget_display, $details_id, $field_parents, $entities) {
+          $entity = $entities[$id];
 
           $display = $field_widget_display->view($entity);
           if (is_string($display)) {


### PR DESCRIPTION
A follow-up to https://github.com/drupal-media/entity_browser/pull/114 for the issue https://www.drupal.org/node/2616782

In that commit, we load the entities earlier, to avoid manipulating entities that have been deleted from the site. Here we store those successfully-loaded entities in an array to be used later, instead of loading them a second time.
