### PR TITLE
Update EntityReference.php

### DIFF
--- a/src/Plugin/Field/FieldWidget/EntityReference.php
+++ b/src/Plugin/Field/FieldWidget/EntityReference.php
@@ -211,7 +211,7 @@ class EntityReference extends WidgetBase implements ContainerFactoryPluginInterf
 
     $ids = [];
     $entities = [];
-    if (($trigger = $form_state->getTriggeringElement()) && in_array($this->fieldDefinition->getName(), $trigger['#parents'])) {
+    if (($trigger = $form_state->getTriggeringElement()) && in_array($this->fieldDefinition->getName(), $trigger['#parents'], TRUE)) {
       // Submit was triggered by hidden "target_id" element when entities were
       // added via entity browser.
       if (!empty($trigger['#ajax']['event']) && $trigger['#ajax']['event'] == 'entity_browser_value_updated') {

--- a/src/Plugin/Field/FieldWidget/EntityReference.php
+++ b/src/Plugin/Field/FieldWidget/EntityReference.php
@@ -211,7 +211,7 @@ class EntityReference extends WidgetBase implements ContainerFactoryPluginInterf
 
     $ids = [];
     $entities = [];
-    if (($trigger = $form_state->getTriggeringElement()) && ((array_pop($trigger) === 'target_id') && (array_pop($trigger) === $this->fieldDefinition->getName()))) {
+    if (($trigger = $form_state->getTriggeringElement()) && ((end($trigger['#parents']) === 'target_id') && ($trigger['#parents'][sizeof($trigger['#parents']) - 2] === $this->fieldDefinition->getName()))) {
       // Submit was triggered by hidden "target_id" element when entities were
       // added via entity browser.
       if (!empty($trigger['#ajax']['event']) && $trigger['#ajax']['event'] == 'entity_browser_value_updated') {

--- a/src/Plugin/Field/FieldWidget/EntityReference.php
+++ b/src/Plugin/Field/FieldWidget/EntityReference.php
@@ -211,7 +211,7 @@ class EntityReference extends WidgetBase implements ContainerFactoryPluginInterf
 
     $ids = [];
     $entities = [];
-    if (($trigger = $form_state->getTriggeringElement()) && in_array($this->fieldDefinition->getName(), $trigger['#parents'], TRUE)) {
+    if (($trigger = $form_state->getTriggeringElement()) && ((array_pop($trigger) === 'target_id') && (array_pop($trigger) === $this->fieldDefinition->getName()))) {
       // Submit was triggered by hidden "target_id" element when entities were
       // added via entity browser.
       if (!empty($trigger['#ajax']['event']) && $trigger['#ajax']['event'] == 'entity_browser_value_updated') {


### PR DESCRIPTION
Add TRUE to in_array() as third argument to fix PHP WTF with in_array(). This corrects some random behavior when using EB on multiple nested paragraph bundles on a page.
