### PR TITLE
Use AJAX for exposed filters, sorts, and pagers.

### DIFF
--- a/entity_browser.module
+++ b/entity_browser.module
@@ -44,30 +44,7 @@ function entity_browser_theme() {
  */
 function entity_browser_form_alter(&$form, FormStateInterface &$form_state) {
   $entity_browser_dialog_edit = \Drupal::service('request_stack')->getCurrentRequest()->get('_route');
-  if ($form['#form_id'] == 'views_exposed_form' && $form_state->getStorage()['display']['display_plugin'] == 'entity_browser') {
-    // Exposed form is not a "real" form when used in context of entitity browser.
-    // Let's just display form elements.
-    $dummy_form = array();
-    /** @var \Drupal\views\ViewExecutable $view */
-    $view = $form_state->get('view');
-    /** @var \Drupal\views\Plugin\views\filter\FilterPluginBase $filter */
-    foreach ($view->filter as $filter) {
-      if ($filter->isExposed()) {
-        $exposed = $filter->exposedInfo();
-        $dummy_key = 'entity_browser_exposed_' . $exposed['value'];
-        $dummy_form[$dummy_key] = $form[$exposed['value']];
-        $dummy_form['#info']['filter-' . $dummy_key] = $form['#info']['filter-' . $filter->field];
-        $dummy_form['#info']['filter-' . $dummy_key]['value'] = $dummy_key;
-      }
-    }
-    $dummy_form['#id'] = '';
-    $dummy_form['#build_id'] = '';
-    $dummy_form['#array_parents'] = [];
-    $dummy_form['#tree'] = '';
-    $dummy_form['#theme'] = $form['#theme'];
-    $form = $dummy_form;
-  }
-  else if ($entity_browser_dialog_edit == 'entity_browser.edit_form') {
+  if ($entity_browser_dialog_edit == 'entity_browser.edit_form') {
     // Let's allow the save button only.
     foreach (Element::children($form['actions']) as $key) {
       $form['actions'][$key]['#access'] = $key == 'submit';

--- a/js/entity_browser.view.js
+++ b/js/entity_browser.view.js
@@ -12,14 +12,27 @@
    */
   Drupal.behaviors.entityBrowserView = {
     attach: function (context) {
-      // Make sure the pager "buttons" trigger a rebuild of the form properly
-      $('.entity-browser-form .pager a').on('click', function(e) {
-        e.preventDefault();
-        var form = $('.entity-browser-form');
-        // Redirect form using the query arguments from the pager
-        form.attr('action', $(this).attr('href'));
-        form.children('[name=filter]').click();
-      });
+      // Add the AJAX to exposed forms.
+      // We do this as the selector in core/modules/views/js/ajax_view.js
+      // assumes that the form the exposed filters reside in has a
+      // views-related ID, which ours does not.
+      var views_instance = Drupal.views.instances[Object.keys(Drupal.views.instances)[0]];
+      if (views_instance) {
+        // Initialize the exposed form AJAX.
+        views_instance.$exposed_form = $('div#views-exposed-form-' + views_instance.settings.view_name.replace(/_/g, '-') + '-' + views_instance.settings.view_display_id.replace(/_/g, '-'));
+        views_instance.$exposed_form.once('exposed-form').each(jQuery.proxy(views_instance.attachExposedFormAjax, views_instance));
+
+        // The form values form_id, form_token, and form_build_id will break
+        // the exposed form. Remove them by splicing the end of form_values.
+        if (views_instance.exposedFormAjax && views_instance.exposedFormAjax.length > 0) {
+          var ajax = views_instance.exposedFormAjax[0];
+          ajax.options.beforeSubmit = function (form_values, element_settings, options) {
+            form_values = form_values.splice(form_values.length - 3, 3);
+            ajax.ajaxing = true;
+            return ajax.beforeSubmit(form_values, element_settings, options);
+          }
+        }
+      }
     }
   }
 

--- a/modules/example/config/install/views.view.nodes_entity_browser.yml
+++ b/modules/example/config/install/views.view.nodes_entity_browser.yml
@@ -1,14 +1,15 @@
 langcode: en
 status: true
 dependencies:
-  module:
-    - entity_browser
-    - entity_browser_example
-    - node
-    - user
   enforced:
     module:
       - entity_browser_example
+  module:
+    - entity_browser
+    - node
+    - user
+_core:
+  default_config_hash: qbtgoaXOPE_c3HSiGBlp8gYrdFLv8ZuFB6zyuOgdvQI
 id: nodes_entity_browser
 label: 'Nodes entity browser'
 module: views
@@ -372,23 +373,63 @@ display:
           entity_type: node
           entity_field: type
           plugin_id: node_type
-      filters: {  }
+      filters:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: word
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: title_op
+            label: Title
+            description: ''
+            use_operator: false
+            operator: title_op
+            identifier: title
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: title
+          plugin_id: string
       sorts:
         created:
           id: created
           table: node_field_data
           field: created
-          order: DESC
-          entity_type: node
-          entity_field: created
-          plugin_id: date
           relationship: none
           group_type: group
           admin_label: ''
-          exposed: false
+          order: DESC
+          exposed: true
           expose:
-            label: ''
+            label: 'Authored on'
           granularity: second
+          entity_type: node
+          entity_field: created
+          plugin_id: date
       header: {  }
       footer: {  }
       empty: {  }
@@ -398,12 +439,20 @@ display:
       filter_groups:
         operator: AND
         groups: {  }
+      use_ajax: true
     cache_metadata:
       contexts:
-        0: node_view_grants
-        1: user
-        3: language
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - 'user.node_grants:view'
+        - user.permissions
       cacheable: false
+      max-age: 0
+      tags: {  }
   entity_browser_1:
     display_plugin: entity_browser
     id: entity_browser_1
@@ -413,7 +462,14 @@ display:
       display_extenders: {  }
     cache_metadata:
       contexts:
-        0: node_view_grants
-        1: user
-        3: language
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'url.query_args:sort_by'
+        - 'url.query_args:sort_order'
+        - 'user.node_grants:view'
+        - user.permissions
       cacheable: false
+      max-age: 0
+      tags: {  }

--- a/src/Plugin/views/field/SelectForm.php
+++ b/src/Plugin/views/field/SelectForm.php
@@ -45,10 +45,8 @@ class SelectForm extends FieldPluginBase {
   /**
    * Form constructor for the bulk form.
    *
-   * @param array $form
+   * @param array $render
    *   An associative array containing the structure of the form.
-   * @param \Drupal\Core\Form\FormStateInterface $form_state
-   *   The current state of the form.
    */
   public function viewsForm(&$render) {
     // Only add the bulk form options and buttons if there are results.
@@ -57,10 +55,15 @@ class SelectForm extends FieldPluginBase {
       $render[$this->options['id']]['#tree'] = TRUE;
       $render[$this->options['id']]['#printed'] = TRUE;
       foreach ($this->view->result as $row_index => $row) {
+        /** @var \Drupal\Core\Entity\EntityInterface $entity */
+        $entity = $row->_entity;
+
         $render[$this->options['id']][$row_index] = [
           '#type' => 'checkbox',
           '#title' => $this->t('Select this item'),
           '#title_display' => 'invisible',
+          '#return_value' => $entity->getEntityTypeId() . ':' . $entity->id(),
+          '#attributes' => ['name' => "entity_browser_select[$row_index]"],
           '#default_value' => NULL,
         ];
       }


### PR DESCRIPTION
This pull request allows (and forces) the View EntityBrowserWidget to use AJAX for filters, sorts, and pagers. In doing this most of the code that previously duped the exposed form functionality has been removed, which hopefully means less technical debt going forward. I'm happy that this came out with more deletions than additions. :beers: :smile: 

This will duplicate functionality from #128, so feel free to close that if needed.
