### PR TITLE
Entity Browser Responsive Modal Dialog

### DIFF
--- a/js/entity_browser.modal.js
+++ b/js/entity_browser.modal.js
@@ -37,4 +37,60 @@
       });
     }
   };
+
+  Drupal.behaviors.fluidModal = {
+    attach: function (context) {
+
+      // on window resize run function
+      $(window).resize(function (context) {
+        fluidDialog();
+      });
+
+      // catch dialog if opened within a viewport smaller than the dialog width
+      // run function on all dialog opens
+      $(document).on("dialogopen", ".ui-dialog", function (event, ui) {
+        fluidDialog();
+      });
+    }
+  };
+
+  var fluidDialog = function fluidDialog() {
+    var $visible = $(".ui-dialog:visible");
+    // each open dialog
+    $visible.each(function () {
+      var $this = $(this);
+      var dialog = $this.find(".ui-dialog-content").data("ui-dialog");
+      // if fluid option == true
+      if (dialog.options.fluid) {
+        var wWidth = $(window).width();
+        // check window width against dialog width
+        if (wWidth < (dialog.options.maxWidth + 50)) {
+          //if there is a maxWidth, don't allow a bigger size
+          dialog.option("width", dialog.options.maxWidth);
+        } else {
+          // if no maxWidth is defined, make it responsive
+          dialog.option("width", '92%');
+        }
+
+        var vHeight = $(window).height();
+        // check window width against dialog width
+        if (vHeight < (dialog.options.maxHeight + 50)) {
+          //if there is a maxHeight, don't allow a bigger size
+          dialog.option("height", dialog.options.maxHeight);
+        } else {
+          // if no maxHeight is defined, make it responsive
+          dialog.option("height", vHeight-100);
+
+          // Because there is no iframe height 100% in HTML 5, we have to set the height of the iframe as well
+          var contentHeight = $this.find('.ui-dialog-content').height() - 20;
+          $this.find("iframe").css("height", contentHeight);
+        }
+
+        //reposition dialog
+        dialog.option("position", dialog.options.position);
+      }
+    });
+  };
+
+
 }(jQuery, Drupal, drupalSettings));

--- a/js/entity_browser.modal.js
+++ b/js/entity_browser.modal.js
@@ -48,13 +48,23 @@
 
       // on window resize run function
       $(window).resize(function (context) {
-        fluidDialog();
+        Drupal.entityBrowser.fluidDialog();
       });
 
       // catch dialog if opened within a viewport smaller than the dialog width
       // run function on all dialog opens
       $(document).on("dialogopen", ".ui-dialog", function (event, ui) {
         Drupal.entityBrowser.fluidDialog();
+      });
+
+      // Disable scrolling of the whole browser window to not interfere with a iframe scrollbar
+      $(window).on({
+        'dialog:aftercreate': function (event, dialog, $element, settings) {
+          $("body").css({ overflow: 'hidden' })
+        },
+        'dialog:beforeclose': function (event, dialog, $element) {
+          $("body").css({ overflow: 'inherit' })
+        }
       });
     }
   };

--- a/js/entity_browser.modal.js
+++ b/js/entity_browser.modal.js
@@ -7,6 +7,8 @@
 
   'use strict';
 
+  Drupal.entityBrowser = {};
+
   Drupal.AjaxCommands.prototype.select_entities = function (ajax, response, status) {
     var uuid = drupalSettings.entity_browser.modal.uuid;
 
@@ -38,6 +40,9 @@
     }
   };
 
+  /**
+   * Registers behaviours related to modal open and windows resize for fluid modal.
+   */
   Drupal.behaviors.fluidModal = {
     attach: function (context) {
 
@@ -49,12 +54,16 @@
       // catch dialog if opened within a viewport smaller than the dialog width
       // run function on all dialog opens
       $(document).on("dialogopen", ".ui-dialog", function (event, ui) {
-        fluidDialog();
+        Drupal.entityBrowser.fluidDialog();
       });
     }
   };
 
-  var fluidDialog = function fluidDialog() {
+  /**
+   * Allows a fluid modal dialog
+   */
+  Drupal.entityBrowser.fluidDialog = function () {
+
     var $visible = $(".ui-dialog:visible");
     // each open dialog
     $visible.each(function () {

--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -210,7 +210,7 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
         'width' => '100%',
         'height' => $this->configuration['height'] - 90,
         'frameborder' => 0,
-        'style' => 'padding:',
+        'style' => 'padding:0',
         'name' => Html::cleanCssIdentifier('entity-browser-iframe-' . $this->configuration['entity_browser_id'])
       ],
     ];
@@ -218,8 +218,13 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
 
     $response = new AjaxResponse();
     $response->addCommand(new OpenModalDialogCommand($this->configuration['link_text'], $html, [
-      'width' => $this->configuration['width'],
-      'height' => $this->configuration['height'],
+      'width' => 'auto',
+      'height' => 'auto',
+      'maxWidth' => $this->configuration['width'],
+      'maxHeight' => $this->configuration['height'],
+      'fluid' => true,
+      'autoResize' => false,
+      'resizable' => false,
     ]));
     return $response;
   }
@@ -364,14 +369,14 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
     $form['width'] = [
       '#type' => 'number',
       '#title' => $this->t('Width of the modal'),
-      '#min' => 1,
       '#default_value' => $configuration['width'],
+      '#description' => t('Empty value for responsive width'),
     ];
     $form['height'] = [
       '#type' => 'number',
       '#title' => $this->t('Height of the modal'),
-      '#min' => 1,
       '#default_value' => $configuration['height'],
+      '#description' => t('Empty value for responsive width'),
     ];
     $form['link_text'] = [
       '#type' => 'textfield',

--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -210,7 +210,7 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
         'width' => '100%',
         'height' => $this->configuration['height'] - 90,
         'frameborder' => 0,
-        'style' => 'padding:',
+        'style' => 'padding:0',
         'name' => Html::cleanCssIdentifier('entity-browser-iframe-' . $this->configuration['entity_browser_id'])
       ],
     ];
@@ -218,8 +218,13 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
 
     $response = new AjaxResponse();
     $response->addCommand(new OpenModalDialogCommand($this->configuration['link_text'], $html, [
-      'width' => $this->configuration['width'],
-      'height' => $this->configuration['height'],
+      'width' => 'auto',
+      'height' => 'auto',
+      'maxWidth' => $this->configuration['width'],
+      'maxHeight' => $this->configuration['height'],
+      'fluid' => true,
+      'autoResize' => false,
+      'resizable' => false,
     ]));
     return $response;
   }
@@ -364,14 +369,14 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
     $form['width'] = [
       '#type' => 'number',
       '#title' => $this->t('Width of the modal'),
-      '#min' => 1,
       '#default_value' => $configuration['width'],
+      '#description' => t('Empty value for responsive width'),
     ];
     $form['height'] = [
       '#type' => 'number',
       '#title' => $this->t('Height of the modal'),
-      '#min' => 1,
       '#default_value' => $configuration['height'],
+      '#description' => t('Empty value for responsive height'),
     ];
     $form['link_text'] = [
       '#type' => 'textfield',

--- a/src/Plugin/EntityBrowser/Display/Modal.php
+++ b/src/Plugin/EntityBrowser/Display/Modal.php
@@ -370,13 +370,13 @@ class Modal extends DisplayBase implements DisplayRouterInterface {
       '#type' => 'number',
       '#title' => $this->t('Width of the modal'),
       '#default_value' => $configuration['width'],
-      '#description' => t('Empty value for responsive width'),
+      '#description' => t('Empty value for responsive width.'),
     ];
     $form['height'] = [
       '#type' => 'number',
       '#title' => $this->t('Height of the modal'),
       '#default_value' => $configuration['height'],
-      '#description' => t('Empty value for responsive height'),
+      '#description' => t('Empty value for responsive height.'),
     ];
     $form['link_text'] = [
       '#type' => 'textfield',


### PR DESCRIPTION
I think, that the entity browser is a key feature for entity reference selection. Especially as soon as we can handle views, it will be crucial to have a responsive dynamic modal. The fixed width / height are quite limiting.

I created a patch to allow the possibility to have empty width / height. The resulting modal will be responsive including the content in the iframe.

![image](https://cloud.githubusercontent.com/assets/432045/13672618/e90ddcb0-e6d5-11e5-8b7d-11bb078403ff.png)
