### PR TITLE
Display an informative message if a plugin has no options

### DIFF
--- a/src/Form/PluginConfigFormBase.php
+++ b/src/Form/PluginConfigFormBase.php
@@ -2,8 +2,11 @@
 
 namespace Drupal\entity_browser\Form;
 
+use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\Core\Render\Element;
 use Drupal\entity_browser\EntityBrowserInterface;
 
 /**
@@ -18,6 +21,16 @@ abstract class PluginConfigFormBase extends FormBase {
     /** @var \Drupal\entity_browser\EntityBrowserInterface $entity_browser */
     $entity_browser = $form_state->getTemporaryValue('wizard')['entity_browser'];
     $form = $this->getPlugin($entity_browser)->buildConfigurationForm($form, $form_state);
+
+    $fields = Element::children($form);
+    if (empty($fields)) {
+      $form['no_options'] = [
+        '#prefix' => '<p>',
+        '#suffix' => '</p>',
+        '#markup' => $this->t('This plugin has no configuration options.'),
+      ];
+    }
+
     return $form;
   }
 
@@ -42,7 +55,7 @@ abstract class PluginConfigFormBase extends FormBase {
   /**
    * Gets plugin that form operates with.
    *
-   * @return \Drupal\Core\Plugin\PluginFormInterface
+   * @return \Drupal\Core\Plugin\PluginFormInterface|\Drupal\Component\Plugin\PluginInspectionInterface
    *   Plugin instance.
    */
   abstract public function getPlugin(EntityBrowserInterface $entity_browser);

--- a/src/Tests/ConfigUITest.php
+++ b/src/Tests/ConfigUITest.php
@@ -82,10 +82,12 @@ class ConfigUITest extends WebTestBase {
 
     // Widget selector step.
     $this->assertUrl('/admin/config/content/entity_browser/test_entity_browser/widget_selector', ['query' => ['js' => 'nojs']]);
+    $this->assertText('This plugin has no configuration options.');
     $this->drupalPostForm(NULL, [], 'Next');
 
     // Selection display step.
     $this->assertUrl('/admin/config/content/entity_browser/test_entity_browser/selection_display', ['query' => ['js' => 'nojs']]);
+    $this->assertText('This plugin has no configuration options.');
     $this->drupalPostForm(NULL, [], 'Next');
 
     // Widgets step.


### PR DESCRIPTION
When experimenting with EB, I found it very confusing that plugins which have no config options simply display "Prev" and "Next" buttons in the wizard, with no additional information. It looks like an error, and fixing it would be a quick UX win.

If a plugin exposes no config options, this PR causes it to provide a message to that effect on its configuration form.
