### PR TITLE
Allow users to provide a path to standalone entity browser

### DIFF
--- a/src/Plugin/EntityBrowser/Display/Standalone.php
+++ b/src/Plugin/EntityBrowser/Display/Standalone.php
@@ -25,6 +25,30 @@ class Standalone extends DisplayBase implements DisplayRouterInterface {
   /**
    * {@inheritdoc}
    */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form['path'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Path'),
+      '#required' => TRUE,
+      '#description' => $this->t('The path at which the browser will be accessible. Must begin with a forward slash.'),
+      '#default_value' => $this->configuration['path'],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    return [
+      'path' => '',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function displayEntityBrowser(FormStateInterface $form_state) {
     // @TODO Implement it.
   }


### PR DESCRIPTION
At the moment, there is no way for a user to set the path to a standalone entity browser through the UI. This PR adds such a configuration option. It worked perfectly for me with manual testing.
